### PR TITLE
MEC1501 header files updated to v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Microchip CPG MEC1501 Peripheral Library
 
 Origin: Microchip CPG
 
-Status: version 0.2
+Status: version 0.3
 
 Purpose: Official peripheral firmware library for MEC1501
 
@@ -24,4 +24,10 @@ License Link: https://www.apache.org/licenses/LICENSE-2.0
 Patch List:
 Update this README.md
 Add header files.
+
+v0.3
+Add array register access to identical arrays of registers in ADC, DMA, ECIA,
+GPIO, and QMSPI.
+Remove unnecessary semi-colons from ESPI_IO.
+Remove unnecessary casting from regaccess.h
 

--- a/mchp/common/regaccess.h
+++ b/mchp/common/regaccess.h
@@ -29,33 +29,33 @@
 
 #include <stdint.h>
 
-#define MMCR32(a)   *((volatile uint32_t *)(uintptr_t)(a))
-#define MMCR16(a)   *((volatile uint16_t *)(uintptr_t)(a))
-#define MMCR8(a)    *((volatile uint8_t *)(uintptr_t)(a))
+#define MMCR32(a)   *((volatile uint32_t *)(a))
+#define MMCR16(a)   *((volatile uint16_t *)(a))
+#define MMCR8(a)    *((volatile uint8_t *)(a))
 
-#define MMCR_RD32(a, v)   v = *((volatile uint32_t *)(uintptr_t)(a))
-#define MMCR_RD16(a, v)   v = *((volatile uint16_t *)(uintptr_t)(a))
-#define MMCR_RD8(a, v)    v = *((volatile uint8_t *)(uintptr_t)(a))
+#define MMCR_RD32(a, v)   v = *((volatile uint32_t *)(a))
+#define MMCR_RD16(a, v)   v = *((volatile uint16_t *)(a))
+#define MMCR_RD8(a, v)    v = *((volatile uint8_t *)(a))
 
-#define MMCR_WR32(a, d)   *((volatile uint32_t *)(uintptr_t)(a)) = (uint32_t)(d)
-#define MMCR_WR16(a, h)   *((volatile uint16_t *)(uintptr_t)(a)) = (uint16_t)(h)
-#define MMCR_WR8(a, b)    *((volatile uint8_t *)(uintptr_t)(a)) = (uint8_t)(b)
+#define MMCR_WR32(a, d)   *((volatile uint32_t *)(a)) = (uint32_t)(d)
+#define MMCR_WR16(a, h)   *((volatile uint16_t *)(a)) = (uint16_t)(h)
+#define MMCR_WR8(a, b)    *((volatile uint8_t *)(a)) = (uint8_t)(b)
 
-#define REG32(a)    *((volatile uint32_t *)(uintptr_t)(a))
-#define REG16(a)    *((volatile uint16_t *)(uintptr_t)(a))
-#define REG8(a)     *((volatile uint8_t *)(uintptr_t)(a))
+#define REG32(a)    *((volatile uint32_t *)(a))
+#define REG16(a)    *((volatile uint16_t *)(a))
+#define REG8(a)     *((volatile uint8_t *)(a))
 
-#define REG32W(a, d)    *((volatile uint32_t *)(uintptr_t)(a)) = (uint32_t)(d)
-#define REG16W(a, h)    *((volatile uint16_t *)(uintptr_t)(a)) = (uint16_t)(h)
-#define REG8W(a, b)     *((volatile uint8_t *)(uintptr_t)(a)) = (uint8_t)(b)
+#define REG32W(a, d)    *((volatile uint32_t *)(a)) = (uint32_t)(d)
+#define REG16W(a, h)    *((volatile uint16_t *)(a)) = (uint16_t)(h)
+#define REG8W(a, b)     *((volatile uint8_t *)(a)) = (uint8_t)(b)
 
-#define REG32R(a, d)    (d) = *(volatile uint32_t *)(uintptr_t)(a)
-#define REG16R(a, h)    (h) = *(volatile uint16_t *)(uintptr_t)(a)
-#define REG8R(a, b)     (b) = *(volatile uint8_t *)(uintptr_t)(a)
+#define REG32R(a, d)    (d) = *(volatile uint32_t *)(a)
+#define REG16R(a, h)    (h) = *(volatile uint16_t *)(a)
+#define REG8R(a, b)     (b) = *(volatile uint8_t *)(a)
 
-#define REG32_OFS(a, ofs)   *(volatile uint32_t *)((uintptr_t)(a) + (uintptr_t)(ofs))
-#define REG16_OFS(a, ofs)   *(volatile uint16_t *)((uintptr_t)(a) + (uintptr_t)(ofs))
-#define REG8_OFS(a, ofs)    *(volatile uint8_t *)((uintptr_t)(a) + (uintptr_t)(ofs))
+#define REG32_OFS(a, ofs)   *(volatile uint32_t *)((uint32_t)(a) + (uint32_t)(ofs))
+#define REG16_OFS(a, ofs)   *(volatile uint16_t *)((uint32_t)(a) + (uint32_t)(ofs))
+#define REG8_OFS(a, ofs)    *(volatile uint8_t *)((uint32_t)(a) + (uint32_t)(ofs))
 
 
 #endif // #ifndef _REGACCESS_H

--- a/mchp/mec1501/MEC1501hsz.h
+++ b/mchp/mec1501/MEC1501hsz.h
@@ -149,7 +149,7 @@ typedef enum IRQn {
 	PHOT_IRQn = 87,	/* GIRQ17 b[17] */
 	/* reserved gap 88-89 */
 	SPISLV_IRQn = 90,	/* GIRQ18 b[0] */
-	QMSPI_IRQn = 91,	/* GIRQ18 b[1] */
+	QMSPI0_IRQn = 91,	/* GIRQ18 b[1] */
 	/* reserved gap 92-99 */
 	PS2_0_ACT_IRQn = 100,	/* GIRQ18 b[10] */
 	PS2_1_ACT_IRQn = 101,	/* GIRQ18 b[11] */
@@ -480,6 +480,10 @@ typedef enum IRQn {
 #define B32TMR1_REGS	((BTMR_Type *) B32TMR1_BASE)
 #define CCT_REGS	((CCT_Type *) (CCT_BASE))
 
+#define DMA_MAX_CHAN	12u
+/* Complete DMA block */
+#define DMA_REGS 	((DMA_Type *) DMA_BASE)
+/* DMA Main only */
 #define DMAM_REGS       ((DMAM_Type *) DMA_BASE)
 /* Individual DMA channels */
 #define DMA0_REGS       ((DMA_CHAN_ALU_Type *)(DMA_CHAN_BASE(0)))
@@ -526,6 +530,7 @@ typedef enum IRQn {
 
 #define RTMR_REGS       ((RTMR_Type *) RTMR_BASE)
 
+#define ADC_MAX_CHAN	8u
 #define ADC_REGS	((ADC_Type *) ADC_BASE)
 
 #define TFDP_REGS	((TFDP_Type *) TFDP_BASE)
@@ -548,6 +553,7 @@ typedef enum IRQn {
 #define LED1_REGS       ((LED_Type *) LED1_BASE)
 #define LED2_REGS       ((LED_Type *) LED2_BASE)
 
+#define ECIA_NUM_GIRQS	(26u-8u+1)
 #define ECIA_REGS       ((ECIA_Type *) ECIA_BASE)
 #define GIRQ08_REGS     ((GIRQ_Type *) ECIA_BASE)
 #define GIRQ09_REGS     ((GIRQ_Type *) ((ECIA_BASE) + 0x14))
@@ -571,15 +577,17 @@ typedef enum IRQn {
 
 #define ECS_REGS        ((ECS_Type *) ECS_BASE)
 
-#define QMSPI_REGS      ((QMSPI_Type *) QMSPI_BASE)
+#define QMSPI_0_MAX_DESCR	16u
+#define QMSPI_0_REGS		((QMSPI_Type *) QMSPI_BASE)
 
 #define PCR_REGS        ((PCR_Type *) PCR_BASE)
 
-#define GPIO_CTRL_REGS      ((GPIO_CTRL_Type *)(GPIO_CTRL_BASE))
-#define GPIO_CTRL2_REGS     ((GPIO_CTRL2_Type *)(GPIO_CTRL2_BASE))
-#define GPIO_PARIN_REGS     ((GPIO_PARIN_Type *)(GPIO_PARIN_BASE))
-#define GPIO_PAROUT_REGS    ((GPIO_PAROUT_Type *)(GPIO_PAROUT_BASE))
-#define GPIO_LOCK_REGS      ((GPIO_LOCK_Type *)(GPIO_LOCK_BASE))
+#define GPIO_REGS		((GPIO_Type *)(GPIO_BASE))
+#define GPIO_CTRL_REGS		((GPIO_CTRL_Type *)(GPIO_CTRL_BASE))
+#define GPIO_CTRL2_REGS		((GPIO_CTRL2_Type *)(GPIO_CTRL2_BASE))
+#define GPIO_PARIN_REGS		((GPIO_PARIN_Type *)(GPIO_PARIN_BASE))
+#define GPIO_PAROUT_REGS	((GPIO_PAROUT_Type *)(GPIO_PAROUT_BASE))
+#define GPIO_LOCK_REGS		((GPIO_LOCK_Type *)(GPIO_LOCK_BASE))
 
 #define MBOX_REGS       ((MBOX_Type *)(MBOX_BASE))
 

--- a/mchp/mec1501/component/adc.h
+++ b/mchp/mec1501/component/adc.h
@@ -157,12 +157,22 @@
 #define MCHP_ADC_SAR_CTRL_WUP_DLY_MASK	(0x3fful << 7)
 #define MCHP_ADC_SAR_CTRL_WUP_DLY_DFLT	(0x202ul << 7)
 
-/* Register interface */
-#define MCHP_ADC_CH_NUM(n) ((n) & MCHP_ADC_MAX_CHAN_MASK)
-#define MCHP_ADC_CH_OFS(n) (MCHP_ADC_CH_NUM(n) << 2)
-#define MCHP_ADC_CH_ADDR(n) (MCHP_ADC_BASE_ADDR + MCHP_ADC_CH_OFS(n))
-
-#define MCHP_ADC_RD_CHAN(n) REG32(MCHP_ADC_CH_ADDR(n))
+/*
+ * Register interface
+ * ba is base address of ADC register block.
+ */
+#define MCHP_ADC_CTRL(ba)		REG32((ba))
+#define MCHP_ADC_DELAY32(ba)		REG32((ba) + 4u)
+#define MCHP_ADC_START_DELAY(ba)	REG16((ba) + 4u)
+#define MCHP_ADC_REPEAT_DELAY(ba)	REG16((ba) + 6u)
+#define MCHP_ADC_STATUS(ba)		REG32((ba) + 8u)
+#define MCHP_ADC_SINGLE_EN(ba)		REG32((ba) + 0x0Cu)
+#define MCHP_ADC_REPEAT_EN(ba)		REG32((ba) + 0x10u)
+#define MCHP_ADC_RD_CHAN(ba, ch)	REG16((ba) + 0x14u + ((ch) * 4))
+#define MCHP_ADC_CONFIG(ba)		REG32((ba) + 0x7Cu)
+#define MCHP_ADC_VREF_CHAN(ba)		REG32((ba) + 0x80u)
+#define MCHP_ADC_VREF_CTRL(ba)		REG32((ba) + 0x84u)
+#define MCHP_ADC_SARADC_CTRL(ba)	REG32((ba) + 0x88u)
 
 /**
   * @brief Analog to Digital Converter Registers (ADC)
@@ -173,14 +183,7 @@ typedef struct adc_regs {
 	__IOM uint32_t STATUS; /*!< (@ 0x0008) ADC Status */
 	__IOM uint32_t SINGLE; /*!< (@ 0x000C) ADC Single */
 	__IOM uint32_t REPEAT; /*!< (@ 0x0010) ADC Repeat */
-	__IOM uint32_t RDCH0; /*!< (@ 0x0014) ADC Chan0 Reading */
-	__IOM uint32_t RDCH1; /*!< (@ 0x0018) ADC Chan1 Reading */
-	__IOM uint32_t RDCH2; /*!< (@ 0x001C) ADC Chan2 Reading */
-	__IOM uint32_t RDCH3; /*!< (@ 0x0020) ADC Chan3 Reading */
-	__IOM uint32_t RDCH4; /*!< (@ 0x0024) ADC Chan4 Reading */
-	__IOM uint32_t RDCH5; /*!< (@ 0x0028) ADC Chan5 Reading */
-	__IOM uint32_t RDCH6; /*!< (@ 0x002C) ADC Chan6 Reading */
-	__IOM uint32_t RDCH7; /*!< (@ 0x0030) ADC Chan7 Reading */
+	__IOM uint32_t RDCH[MCHP_ADC_MAX_CHAN]; /*!< (@ 0x0014 - 0x0030) ADC Chan 0-7 reading value */
 	uint8_t RSVD1[0x7C - 0x34];
 	__IOM uint32_t CONFIG; /*!< (@ 0x007C) ADC Configuration */
 	__IOM uint32_t VREF_CHAN_SEL; /*!< (@ 0x0080) ADC Vref Channel Sel. */

--- a/mchp/mec1501/component/ecia.h
+++ b/mchp/mec1501/component/ecia.h
@@ -41,6 +41,7 @@
 #define MCHP_ECIA_ADDR	0x4000E000ul
 #define MCHP_FIRST_GIRQ	8u
 #define MCHP_LAST_GIRQ	26u
+#define MCHP_NUM_GIRQS (MCHP_LAST_GIRQ - MCHP_FIRST_GIRQ + 1)
 
 #define MCHP_ECIA_GIRQ_NO_NVIC	 22u
 
@@ -53,6 +54,12 @@
 	(1ul << 17) + (1ul << 18) +\
 	(1ul << 19) + (1ul << 20) +\
 	(1ul << 21) + (1ul << 23))
+
+/*
+ * All external NVIC connections equal to or above this value are
+ * direct peripheral interrupts.
+ */
+#define MCHP_ECIA_FIRST_DIRECT_NVIC	20u
 
 /*
  * ARM Cortex-M4 NVIC registers
@@ -382,6 +389,18 @@ typedef struct ecia_regs
 	__IOM uint32_t BLK_EN_CLR;	/*! (@ 0x00000204) Aggregated GIRQ output Enable Clear */
 	__IM uint32_t BLK_ACTIVE;	/*! (@ 0x00000204) GIRQ Active bitmap (RO) */
 } ECIA_Type;
+
+/*
+ * ECIA registers with GIRQ accessible as an array
+ */
+typedef struct ecia_gar_regs
+{
+	GIRQ_Type GIRQ[MCHP_NUM_GIRQS]; /*!< (@ 0x0000-0x17B) GIRQ08-GIRQ26 */
+	uint8_t RSVD1[(0x0200ul - 0x017Cul)];	/* offsets 0x017C - 0x1FF */
+	__IOM uint32_t BLK_EN_SET;	/*! (@ 0x00000200) Aggregated GIRQ output Enable Set */
+	__IOM uint32_t BLK_EN_CLR;	/*! (@ 0x00000204) Aggregated GIRQ output Enable Clear */
+	__IM uint32_t BLK_ACTIVE;	/*! (@ 0x00000204) GIRQ Active bitmap (RO) */
+} ECIA_GAR_Type;
 
 #endif				// #ifndef _ECIA_H
 /* end ecia.h */

--- a/mchp/mec1501/component/espi_io.h
+++ b/mchp/mec1501/component/espi_io.h
@@ -188,16 +188,16 @@
 	((0x01u) << (MCHP_ESPI_FC_CAP_MAX_RD_SZ_POS))
 
 /* PC Ready */
-#define MCHP_ESPI_PC_READY_MASK		0x01u;
-#define MCHP_ESPI_PC_READY		0x01u;
+#define MCHP_ESPI_PC_READY_MASK		0x01u
+#define MCHP_ESPI_PC_READY		0x01u
 
 /* OOB Ready */
-#define MCHP_ESPI_OOB_READY_MASK	0x01u;
-#define MCHP_ESPI_OOB_READY		0x01u;
+#define MCHP_ESPI_OOB_READY_MASK	0x01u
+#define MCHP_ESPI_OOB_READY		0x01u
 
 /* FC Ready */
-#define MCHP_ESPI_FC_READY_MASK		0x01u;
-#define MCHP_ESPI_FC_READY		0x01u;
+#define MCHP_ESPI_FC_READY_MASK		0x01u
+#define MCHP_ESPI_FC_READY		0x01u
 
 /* ESPI_RESET# Interrupt Status */
 #define MCHP_ESPI_RST_ISTS_MASK		0x03u;

--- a/mchp/mec1501/component/gpio.h
+++ b/mchp/mec1501/component/gpio.h
@@ -38,6 +38,8 @@
 
 #define NUM_MCHP_GPIO_PORTS	6u
 #define MAX_NUM_MCHP_GPIO	(NUM_MCHP_GPIO_PORTS * 32u)
+#define MCHP_LAST_GPIO		0255u
+#define MCHP_MAX_GPIO		(MCHP_LAST_GPIO + 1u)
 
 #define MCHP_GPIO_CTRL_BASE	0x40081000ul
 #define MCHP_GPIO_PARIN_OFS	0x0300ul
@@ -865,8 +867,21 @@ typedef struct gpio_lock_regs {
 	__IOM uint32_t LOCK0;	/*!< (@ 0x0014) GPIO Lock 0 */
 } GPIO_LOCK_Type;
 
+typedef struct gpio_regs {
+	__IOM uint32_t CTRL[MCHP_MAX_GPIO]; /*!< (@ 0x0000) GPIO Control */
+	uint32_t RSVD1[(0x0300ul/4) - MCHP_MAX_GPIO];
+	__IOM uint32_t PARIN[NUM_MCHP_GPIO_PORTS]; /*!< (@ 0x0300) GPIO parallel input */
+	uint32_t RSVD2[((0x0380ul-0x300ul)/4) - NUM_MCHP_GPIO_PORTS];
+	__IOM uint32_t PAROUT[NUM_MCHP_GPIO_PORTS]; /*!< (@ 0x0380) GPIO parallel output */
+	uint32_t RSVD3[((0x03E8ul-0x0380ul)/4) - NUM_MCHP_GPIO_PORTS];
+	__IOM uint32_t LOCK[NUM_MCHP_GPIO_PORTS]; /*!< (@ 0x03E8) GPIO lock */
+	uint32_t RSVD4[((0x0500ul-0x03E8ul)/4) - NUM_MCHP_GPIO_PORTS];
+	__IOM uint32_t CTRL2[MAX_NUM_MCHP_GPIO]; /*!< (@ 0x0500) GPIO Control 2 */
+} GPIO_Type;
+
 /*
- * Helper functions
+ * GPIO control field values.
+ * Value must be shifted to the proper control register position.
  */
 enum mchp_gpio_pud {
 	MCHP_GPIO_NO_PUD = 0ul,
@@ -939,102 +954,6 @@ enum mchp_gpio_drv_str {
 	MCHP_GPIO_DRV_STR_8MA = 2ul,
 	MCHP_GPIO_DRV_STR_12MA = 3ul,
 };
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_pud_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_pud pud)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_PUD_MASK))
-		| (((uint32_t) pud << MCHP_GPIO_CTRL_PUD_POS)
-		& MCHP_GPIO_CTRL_PUD_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_pwrgt_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_pwrgate pwrgt)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_PWRG_MASK))
-		| (((uint32_t) pwrgt << MCHP_GPIO_CTRL_PWRG_POS)
-		& MCHP_GPIO_CTRL_PWRG_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_idet_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_idet idet)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_IDET_MASK))
-		| (((uint32_t) idet << MCHP_GPIO_CTRL_IDET_POS)
-		& MCHP_GPIO_CTRL_IDET_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_outbuf_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_outbuf outbuf)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_BUFT_MASK))
-		| (((uint32_t) outbuf << MCHP_GPIO_CTRL_BUFT_POS)
-		& MCHP_GPIO_CTRL_BUFT_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_dir_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_dir dir)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_DIR_MASK))
-		| (((uint32_t) dir << MCHP_GPIO_CTRL_DIR_POS)
-		& MCHP_GPIO_CTRL_DIR_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_parout_en_set(uintptr_t gp_ctrl_addr,
-			enum mchp_gpio_parout_en parout_en)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_AOD_MASK))
-		| (((uint32_t) parout_en << MCHP_GPIO_CTRL_AOD_POS)
-		& MCHP_GPIO_CTRL_AOD_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_pol_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_pol pol)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_POL_MASK))
-		| (((uint32_t) pol << MCHP_GPIO_CTRL_POL_POS)
-		& MCHP_GPIO_CTRL_POL_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_mux_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_mux mux)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_MUX_MASK))
-		| (((uint32_t) mux << MCHP_GPIO_CTRL_MUX_POS)
-		& MCHP_GPIO_CTRL_MUX_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_inpad_ctrl_set(uintptr_t gp_ctrl_addr,
-			enum mchp_gpio_inpad_ctrl inpad_ctrl)
-{
-	REG32(gp_ctrl_addr) =
-		(REG32(gp_ctrl_addr) & ~(MCHP_GPIO_CTRL_INPAD_DIS_MASK))
-		| (((uint32_t) inpad_ctrl << MCHP_GPIO_CTRL_INPAD_DIS_POS)
-		& MCHP_GPIO_CTRL_INPAD_DIS_MASK);
-}
-
-static __attribute__ ((always_inline)) inline void
-mchp_gpio_alt_out_set(uintptr_t gp_ctrl_addr, enum mchp_gpio_alt_out aout_state)
-{
-	REG8(gp_ctrl_addr + 2ul) =
-		(uint8_t) aout_state & MCHP_GPIO_CTRL_OUTVAL_MASK0;
-}
-
-static __attribute__ ((always_inline)) inline uint8_t
-mchp_gpio_inpad_val_get(uintptr_t gp_ctrl_addr, enum mchp_gpio_alt_out aout_state)
-{
-	return REG8(gp_ctrl_addr + 3ul) & MCHP_GPIO_CTRL_INPAD_VAL_MASK0;
-}
 
 #endif				/* #ifndef _GPIO_H */
 /* end gpio.h */


### PR DESCRIPTION
Add register array access to identical ranges of registers
and register structures for ADC, DMA, ECIA, GPIO, and QMSPI.
Clean up regaccess.h and ESPI_IO syntax.

Signed-off-by: Scott Worley <scott.worley@microchip.com>