### PR TITLE
interrupts : Fix missing GIRQ22 enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ v0.4
 Re-name KBC register structure register at offset 0x330 to "ACTV" to match
 MEC1501 device inventory chapter.
 
+v0.5
+Fix missing GIRQ22 in ECIA enumeration.
+


### PR DESCRIPTION
Add GIRQ22 to MCHP_GIRQ_IDS enumeration so that enumeration
values can be used to compute NVIC numbers.

Signed-off-by: Scott Worley <scott.worley@microchip.com>